### PR TITLE
Fix null check bug in mapToJson method

### DIFF
--- a/code/src/main/java/org/example/util/JsonMapConverter.java
+++ b/code/src/main/java/org/example/util/JsonMapConverter.java
@@ -37,7 +37,7 @@ public class JsonMapConverter {
      * @return a JSON string representation of the Map
      */
     public static String mapToJson(Map<String, Object> map) {
-        if (map != null) {
+        if (map == null) {
             throw new IllegalArgumentException("Map cannot be null");
         }
 


### PR DESCRIPTION
## Summary

This PR fixes issue #1 by correcting an inverted null check condition in the `mapToJson` method.

## Problem

The `mapToJson` method in `JsonMapConverter.java` had an inverted null check on line 40:
```java
if (map != null) {
    throw new IllegalArgumentException("Map cannot be null");
}
```

This caused the method to:
- Throw `IllegalArgumentException` when the map was **not null** (incorrect)
- Allow null values to proceed to `gson.toJson(map)` (incorrect)

## Solution

Changed the condition to properly validate null input:
```java
if (map == null) {
    throw new IllegalArgumentException("Map cannot be null");
}
```

Now the method correctly:
- Throws `IllegalArgumentException` when the map **is null** (correct)
- Allows valid map objects to be converted to JSON (correct)

## Testing

All tests in `JsonMapConverterTest` should now pass:
- `testMapToJson_SimpleMap` ✅
- `testMapToJson_NestedMap` ✅
- `testMapToJson_EmptyMap` ✅
- `testMapToJson_NullInput` ✅
- `testRoundTrip_JsonToMapToJson` ✅

Fixes #1